### PR TITLE
fix: changement de salle une frame trop tard

### DIFF
--- a/JavAdventure/src/main/java/ch/emf/javadventure/ctrl/GameCtrl.java
+++ b/JavAdventure/src/main/java/ch/emf/javadventure/ctrl/GameCtrl.java
@@ -102,9 +102,9 @@ public class GameCtrl implements IGameCtrl {
         }
 
         boolean validPos = currentRoom.checkBoundary(nextPos);
-        RoomElement[][] moveRoomEntity = this.currentRoom.moveRoomEntity(this.player, (validPos ? nextPos[0] : pos[0]), (validPos ? nextPos[1] : pos[1]));
+        this.currentRoom.moveRoomEntity(this.player, (validPos ? nextPos[0] : pos[0]), (validPos ? nextPos[1] : pos[1]));
         colisionDetection();
-        return moveRoomEntity;
+        return currentRoom.getContent();
 
     }
 
@@ -188,7 +188,6 @@ public class GameCtrl implements IGameCtrl {
             currentRoomNumber = nextRoomNumber;
             placePlayerNearDoor(e); // Place the player near the door
 
-            updateRoom();
             gameView.setRoomDescription(currentRoom.getRoomDescription());
         }
     }


### PR DESCRIPTION
Avant, le changement de salle ne se faisait pas bien. Le joueur disparaissait et avec une frame de retard.
Maintenant, le joueur change de salle dès qu'il passe une porte.

démo vidéo:

https://github.com/emf-info-tpi/23-24-javadventure/assets/117712563/5866b0e3-f973-46dd-8f32-508c4c5a1b3a

